### PR TITLE
<feat> support the community version

### DIFF
--- a/src/main/java/com/mongodb/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/jdbc/MongoConnection.java
@@ -617,8 +617,9 @@ public class MongoConnection implements Connection {
                     break;
                 case Community:
                     // Community edition is disallowed.
-                    throw new SQLException(
-                            "Community edition detected. The JDBC driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation.");
+                    // throw new SQLException(
+                    //         "Community edition detected. The JDBC driver is intended for use with MongoDB Enterprise edition or Atlas Data Federation.");
+                    break;
                 case Enterprise:
                     String version = MongoDriver.getVersion();
                     if (MongoDriver.isEapBuild()) {

--- a/src/main/java/com/mongodb/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/jdbc/MongoStatement.java
@@ -308,7 +308,8 @@ public class MongoStatement implements Statement {
             } else if (conn.getClusterType() == MongoConnection.MongoClusterType.Enterprise) {
                 result = executeDirectClusterQuery(sql);
             } else {
-                throw new SQLException("Unsupported cluster type: " + conn.clusterType);
+                //throw new SQLException("Unsupported cluster type: " + conn.clusterType);
+                result = executeDirectClusterQuery(sql);
             }
         } catch (MongoExecutionTimeoutException e) {
             throw new SQLTimeoutException(e);


### PR DESCRIPTION
support the community version

## Summary by Sourcery

Enable support for MongoDB Community edition by removing errors for community cluster types and using the direct query path for those clusters.

New Features:
- Allow connections to MongoDB Community edition by disabling the edition check in MongoConnection
- Route queries on Community clusters to executeDirectClusterQuery instead of throwing unsupported cluster errors